### PR TITLE
Wait for preview thread to stop

### DIFF
--- a/Source/RGExpandedWorldGeneration/Patches/CanDoNext_Patch.cs
+++ b/Source/RGExpandedWorldGeneration/Patches/CanDoNext_Patch.cs
@@ -11,6 +11,7 @@ public static class CanDoNext_Patch
         if (Page_CreateWorldParams_Patch.thread != null)
         {
             Page_CreateWorldParams_Patch.thread.Abort();
+            Page_CreateWorldParams_Patch.thread.Join(1000);
             Page_CreateWorldParams_Patch.thread = null;
         }
 

--- a/Source/RGExpandedWorldGeneration/Patches/Page_CreateWorldParams_Patch.cs
+++ b/Source/RGExpandedWorldGeneration/Patches/Page_CreateWorldParams_Patch.cs
@@ -295,6 +295,7 @@ public static class Page_CreateWorldParams_Patch
             if (thread != null)
             {
                 thread.Abort();
+                thread.Join(1000);
                 thread = null;
             }
         }
@@ -439,6 +440,7 @@ public static class Page_CreateWorldParams_Patch
         if (thread is { IsAlive: true })
         {
             thread.Abort();
+            thread.Join(1000);
             generatingWorld = false;
         }
 


### PR DESCRIPTION
Currently the world preview feature can cause NREs and other exceptions to randomly occur in both vanilla and modded code. This happens when the actual world starts generating while a preview thread is not fully stopped yet.